### PR TITLE
chore: add task for user intent parser

### DIFF
--- a/tasks/parser-intencji-uzytkownika.md
+++ b/tasks/parser-intencji-uzytkownika.md
@@ -1,0 +1,14 @@
+# Parser intencji użytkownika
+
+**Cel:** Zbudować parser intencji użytkownika korzystający z pytań w plikach `FAQ LARP GOTHIC.md` oraz `rules.md`.
+
+**Opis:**
+- Na podstawie treści pytań z obu plików przygotować listę kategorii, np. "walka", "alchemia", "mechanika śmierci".
+- Parser powinien dla danego pytania zwracać:
+  - typ pytania (kategoria)
+  - dopasowany alias promptowy wykorzystywany w interfejsie LLM.
+
+**Kryteria akceptacji:**
+- Zebrane i opisane co najmniej podstawowe kategorie pytań.
+- Dla każdej kategorii ustalony alias promptowy.
+- Dodane testy weryfikujące poprawne rozpoznawanie kategorii na przykładowych pytaniach.


### PR DESCRIPTION
## Summary
- add planning task for building a user intent parser from FAQ and rules

## Testing
- `python3 -m pytest` *(fails: python3 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b42c8ef1fc832192ee616f598b170b