### PR TITLE
feat: scaffold intent parser and retrieval tests

### DIFF
--- a/phi3_ui.py
+++ b/phi3_ui.py
@@ -1,8 +1,0 @@
-"""Entry point for the phi3 UI application."""
-
-from src.app import build_app
-
-
-if __name__ == "__main__":
-    app = build_app()
-    app.launch(server_name="0.0.0.0", server_port=7860, inbrowser=False)

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,0 +1,5 @@
+from typing import Dict
+
+def parse_intent(user_input: str) -> Dict:
+    """Parse user input into an intent dictionary."""
+    raise NotImplementedError("Intent parser not implemented yet")

--- a/src/prompt_enhancer.py
+++ b/src/prompt_enhancer.py
@@ -1,0 +1,5 @@
+from typing import Dict
+
+def enhance_prompt(parsed: Dict, context: str) -> str:
+    """Enhance prompt based on parsed intent and context."""
+    raise NotImplementedError("Prompt enhancer not implemented yet")

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from src.retrieval import BM25Index, md_to_pages
+
+
+def test_md_to_pages_splits_file():
+    md_text = "# T\n\n" + "Lorem ipsum " * 100
+    pages = md_to_pages(md_text, page_chars=100)
+    assert len(pages) > 1
+    assert pages[0]["page"] == 1 and pages[1]["page"] == 2
+
+
+def test_bm25_index_search_returns_results():
+    rules_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "rules.md")
+    with open(rules_path, "r", encoding="utf-8") as f:
+        rules_text = f.read()
+    pages = md_to_pages(rules_text)
+    index = BM25Index(pages)
+    results = index.search("Jak się walczy?")
+    assert len(results) > 0


### PR DESCRIPTION
## Summary
- scaffold placeholder modules for intent parsing and prompt enhancement
- add retrieval tests for markdown paging and BM25 search
- remove obsolete phi3_ui entrypoint

## Testing
- `pytest -q` *(fails: No module named 'rank_bm25')*


------
https://chatgpt.com/codex/tasks/task_e_68b430668cf88321975dc352be0f5ac2