### PR TITLE
Improve topic relevance and debug info in Q&A

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -36,11 +36,11 @@ def build_app():
         q = gr.Textbox(label="Twoje pytanie", placeholder="Np. Jak się walczy?", lines=2)
         ask = gr.Button("Zapytaj", variant="primary")
 
-        parser_info = gr.Markdown(label="Parser")
         answer = gr.Markdown(label="Odpowiedź")
+        debug_bar = gr.Markdown(label="Debug")
         context = gr.Markdown(label="Źródła i kontekst")
 
-        ask.click(fn=handle_question, inputs=q, outputs=[parser_info, answer, context])
+        ask.click(fn=handle_question, inputs=q, outputs=[answer, debug_bar, context])
 
     return demo
 

--- a/src/prompt_enhancer.py
+++ b/src/prompt_enhancer.py
@@ -7,7 +7,8 @@ def enhance_prompt(question: str, intent: Dict, context: str) -> str:
     intent_line = f"Dopasowane pytanie: {intent.get('match', '')} (pewność {intent.get('confidence', 0):.2f})"
     answer_format = (
         "FORMAT ODPOWIEDZI (stosuj dokładnie):\n"
-        "Odpowiedź: <2–4 krótkie zdania, tylko fakty z kontekstu; jeśli brak – 'Nie ma tego w podręczniku.'>\n"
+        "Odpowiedź: <2–4 krótkie zdania, tylko fakty z najtrafniejszych fragmentów powiązanych z tematem pytania (np. 'walka', 'magia'). Jeśli brak – napisz: 'Nie ma tego w podręczniku.'>\n"
+        "Nie cytuj fragmentów niepowiązanych tematycznie (np. alchemii dla pytania o walkę).\n"
         "Cytaty: \"<cytat1>\" ; \"<cytat2>\" (każdy ≤ 20 słów, dosłownie z kontekstu; jeśli masz tylko jeden – podaj jeden)\n"
         "Źródła: [Strona X — Sekcja: Y]; [Strona …]"
     )

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from src import llm_client
+
+
+class DummyIndex:
+    def search(self, query: str, k: int):
+        return [
+            {"page": 1, "section": "Alchemia", "preview": "a"},
+            {"page": 2, "section": "Walka", "preview": "b"},
+            {"page": 3, "section": "Smierc", "preview": "c"},
+        ]
+
+
+def test_answer_question_reorders_by_intent(monkeypatch):
+    def fake_parse_intent(q):
+        return {"match": "walka zasady", "confidence": 0.6}
+
+    monkeypatch.setattr(llm_client, "parse_intent", fake_parse_intent)
+    monkeypatch.setattr(llm_client, "call_llama", lambda messages, seed: "Nie ma tego w podręczniku")
+
+    ans, debug, ctx = llm_client.answer_question(DummyIndex(), "Jak się walczy?")
+    assert ans == "[Popraw: cytat błędny – mimo obecności kontekstu]"
+    assert "Sekcje: 2:Walka, 1:Alchemia, 3:Smierc" in debug
+    assert ctx.splitlines()[0].startswith("[1] Strona 2")
+
+
+def test_answer_question_preserves_order_on_low_conf(monkeypatch):
+    def fake_parse_intent(q):
+        return {"match": "walka zasady", "confidence": 0.4}
+
+    monkeypatch.setattr(llm_client, "parse_intent", fake_parse_intent)
+    monkeypatch.setattr(llm_client, "call_llama", lambda messages, seed: "odp")
+
+    ans, debug, ctx = llm_client.answer_question(DummyIndex(), "Jak się walczy?")
+    assert ans == "odp"
+    assert "Sekcje: 1:Alchemia, 2:Walka, 3:Smierc" in debug
+    assert ctx.splitlines()[0].startswith("[1] Strona 1")

--- a/tests/test_prompt_enhancer.py
+++ b/tests/test_prompt_enhancer.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from src.prompt_enhancer import enhance_prompt
+
+
+def test_enhance_prompt_mentions_topic_relevance():
+    prompt = enhance_prompt(
+        "Jak się walczy?",
+        {"match": "walka", "confidence": 0.7},
+        "[1] Strona 1 — Sekcja: Walka\nPrzykładowy tekst"
+    )
+    assert "najtrafniejszych fragmentów powiązanych z tematem pytania" in prompt
+    assert "Nie cytuj fragmentów niepowiązanych tematycznie" in prompt


### PR DESCRIPTION
## Summary
- refactor prompt format to emphasise topic-relevant snippets and avoid unrelated citations
- boost retrieval results by sorting sections matching parsed intent and remove false "no answer" messages when context exists
- add parser/section debug bar in UI with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43abbc1148321a70675465ee29fb6