### PR TITLE
fix: resolve intent catalog paths relative to module

### DIFF
--- a/gothic_rag_ui_parser.py
+++ b/gothic_rag_ui_parser.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import unicodedata
+from pathlib import Path
 from typing import List, Dict, Tuple
 
 try:
@@ -173,7 +174,11 @@ def expand_keywords(q: str) -> str:
 # Intent parsing
 # -----------------------------
 INTENT_KEYWORDS = {k: [k] + v for k, v in KEYWORD_MAP.items()}
-INTENT_FILES = ["FAQ LARP GOTHIC.md", "rules.md"]
+MODULE_DIR = Path(__file__).resolve().parent
+INTENT_FILES = [
+    str(MODULE_DIR / "FAQ LARP GOTHIC.md"),
+    str(MODULE_DIR / "rules.md"),
+]
 
 
 def _detect_intent(text: str) -> str:


### PR DESCRIPTION
## Summary
- resolve intent catalog paths relative to module directory to ensure catalog loads regardless of CWD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b443cb746883219ec57e3081543c52