### PR TITLE
fix: guard retrieval dependencies and chunk long markdown blocks

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,11 @@ import re
 import unicodedata
 from typing import List
 
-from unidecode import unidecode
+try:
+    from unidecode import unidecode
+except ModuleNotFoundError:  # pragma: no cover - fallback when dependency missing
+    def unidecode(text: str) -> str:  # type: ignore[return-type]
+        return text
 
 
 def normalize(txt: str) -> str:


### PR DESCRIPTION
## Summary
- allow importing retrieval utilities without rank_bm25 installed
- gracefully degrade when unidecode missing
- ensure `md_to_pages` slices blocks that meet or exceed page size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b443fb92e083218c339239f86529e4