### PR TITLE
feat: add monitoring and debug utilities

### DIFF
--- a/log_tester.py
+++ b/log_tester.py
@@ -1,0 +1,19 @@
+"""Verify integrity of log.txt entries after stress testing."""
+
+import re
+from pathlib import Path
+
+LOG_PATH = Path("log.txt")
+
+
+def check() -> None:
+    text = LOG_PATH.read_text(encoding="utf-8")
+    prompts = len(re.findall(r"^PROMPT:", text, flags=re.MULTILINE))
+    answers = len(re.findall(r"^ANSWER:", text, flags=re.MULTILINE))
+    if prompts != answers:
+        raise AssertionError(f"Mismatch: {prompts} prompts vs {answers} answers")
+    print(f"log entries: {prompts}")
+
+
+if __name__ == "__main__":
+    check()

--- a/src/debug_mode.py
+++ b/src/debug_mode.py
@@ -1,0 +1,14 @@
+"""Global toggle for debug mode in the UI."""
+
+DEBUG_MODE = False
+
+
+def set_debug(value: bool) -> None:
+    """Enable or disable debug mode."""
+    global DEBUG_MODE
+    DEBUG_MODE = bool(value)
+
+
+def is_debug() -> bool:
+    """Return whether debug mode is enabled."""
+    return DEBUG_MODE

--- a/src/embedder_local.py
+++ b/src/embedder_local.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Simple offline-safe text embedder using a bag-of-words representation."""
+
+from collections import Counter
+from typing import Iterable, List
+
+
+class LocalEmbedder:
+    """Create vector representations without external dependencies."""
+
+    def __init__(self) -> None:
+        self.vocab: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    def fit(self, corpus: Iterable[str]) -> None:
+        words = set()
+        for doc in corpus:
+            words.update(doc.lower().split())
+        self.vocab = {w: i for i, w in enumerate(sorted(words))}
+
+    # ------------------------------------------------------------------
+    def encode(self, texts: Iterable[str]) -> List[List[int]]:
+        vectors: List[List[int]] = []
+        for text in texts:
+            counts = Counter(text.lower().split())
+            vec = [counts.get(w, 0) for w in self.vocab]
+            vectors.append(vec)
+        return vectors

--- a/src/gradio_ui.py
+++ b/src/gradio_ui.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Gradio UI with optional debug mode showing full logs."""
+
+from pathlib import Path
+
+import gradio as gr
+
+from . import debug_mode
+from .llm_client import answer_question
+from .retrieval import BM25Index, md_to_pages
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def _load_index() -> BM25Index:
+    pages = []
+    for md_path in DATA_DIR.glob("*.md"):
+        pages.extend(md_to_pages(md_path.read_text(encoding="utf-8")))
+    return BM25Index(pages)
+
+
+INDEX = _load_index()
+
+
+def handle_question(question: str) -> tuple[str, str, str, str]:
+    out, debug_bar, ctx = answer_question(INDEX, question)
+    logs = ""
+    if debug_mode.is_debug():
+        logs = f"PROMPT:\n{question}\n\nRETRIEVAL:\n{ctx}\n\nODPOWIEDŹ:\n{out}"
+    return out, debug_bar, ctx, logs
+
+
+def toggle_debug(enabled: bool) -> gr.components.Textbox:
+    debug_mode.set_debug(enabled)
+    return gr.Textbox.update(visible=enabled)
+
+
+def build_app():
+    """Create Gradio Blocks application with debug toggle."""
+    with gr.Blocks(css=".gr-textbox textarea {font-size: 14px}") as demo:
+        gr.Markdown(
+            """
+        # 📜 Gothic LARP – Podręcznik Q&A (RAG)
+        Wpisz pytanie dotyczące zasad. Aplikacja automatycznie wczytuje pliki Markdown z katalogu `data`.
+        """
+        )
+
+        q = gr.Textbox(label="Twoje pytanie", placeholder="Np. Jak się walczy?", lines=2)
+        debug_toggle = gr.Checkbox(label="Tryb debug", value=False)
+        ask = gr.Button("Zapytaj", variant="primary")
+
+        answer = gr.Markdown(label="Odpowiedź")
+        debug_bar = gr.Markdown(label="Debug")
+        context = gr.Markdown(label="Źródła i kontekst")
+        logs = gr.Textbox(label="Pełne logi", lines=10, visible=False)
+
+        debug_toggle.change(fn=toggle_debug, inputs=debug_toggle, outputs=logs)
+        ask.click(fn=handle_question, inputs=q, outputs=[answer, debug_bar, context, logs])
+
+    return demo
+
+
+if __name__ == "__main__":
+    app = build_app()
+    app.launch(server_name="0.0.0.0", server_port=7860, inbrowser=False)

--- a/src/metrics_logger.py
+++ b/src/metrics_logger.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Utility for logging basic performance metrics."""
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class MetricsRecord:
+    """Container for timing information."""
+
+    start_time: float
+    first_response_time: float | None = None
+    end_time: float | None = None
+
+    @property
+    def total_duration(self) -> float | None:
+        if self.end_time is None:
+            return None
+        return self.end_time - self.start_time
+
+    @property
+    def time_to_first_response(self) -> float | None:
+        if self.first_response_time is None:
+            return None
+        return self.first_response_time - self.start_time
+
+
+class MetricsLogger:
+    """Log start, first response and total duration to a JSONL file."""
+
+    def __init__(self, log_file: str | Path = "metrics.log") -> None:
+        self.log_file = Path(log_file)
+        self.record: MetricsRecord | None = None
+
+    def start(self) -> None:
+        """Mark start time."""
+        self.record = MetricsRecord(start_time=time.time())
+
+    def first_response(self) -> None:
+        """Mark time of first response if not already set."""
+        if self.record and self.record.first_response_time is None:
+            self.record.first_response_time = time.time()
+
+    def end(self) -> None:
+        """Mark end time and persist record."""
+        if not self.record:
+            return
+        self.record.end_time = time.time()
+        self._write_record()
+
+    # ------------------------------------------------------------------
+    def _write_record(self) -> None:
+        if not self.record:
+            return
+        data = {
+            "start_time": self.record.start_time,
+            "first_response_time": self.record.first_response_time,
+            "total_duration": self.record.total_duration,
+        }
+        with self.log_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(data) + "\n")

--- a/src/query_monitor.py
+++ b/src/query_monitor.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Anonymised logging of user queries."""
+
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "user_logs"
+
+
+def log_query(query: str) -> Path:
+    """Persist query with random UUID and timestamp.
+
+    Parameters
+    ----------
+    query: str
+        Raw user question to store.
+    """
+    LOG_DIR.mkdir(exist_ok=True)
+    entry = {
+        "uuid": str(uuid.uuid4()),
+        "timestamp": datetime.utcnow().isoformat(),
+        "query": query,
+    }
+    path = LOG_DIR / f"{entry['uuid']}.json"
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False)
+    return path

--- a/stress_test.py
+++ b/stress_test.py
@@ -1,0 +1,26 @@
+"""Concurrency stress test for log.txt writing."""
+
+import threading
+from pathlib import Path
+from src.llm_client import _log
+
+LOG_PATH = Path("log.txt")
+
+
+def worker(i: int) -> None:
+    for j in range(20):
+        _log(f"prompt-{i}-{j}", f"answer-{i}-{j}")
+
+
+def main() -> None:
+    LOG_PATH.unlink(missing_ok=True)
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    print("stress test completed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log performance metrics with a dedicated `MetricsLogger`
- add anonymised query monitor and debug-mode UI with full logs
- include offline-safe embedder and scripts for log stress testing

## Testing
- `pytest`
- `python stress_test.py`
- `python log_tester.py`


------
https://chatgpt.com/codex/tasks/task_e_68b45638e2bc8321b950e2ff245bbd6d