### PR TITLE
feat: add microphone input with Whisper transcription and FAQ tiles

### DIFF
--- a/frequent_questions.json
+++ b/frequent_questions.json
@@ -1,0 +1,5 @@
+[
+  "Jak się walczy?",
+  "Jak działają zaklęcia?",
+  "Jak zdobyć doświadczenie?"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rank_bm25
 requests
 unidecode
 rapidfuzz
+openai-whisper

--- a/src/gradio_ui.py
+++ b/src/gradio_ui.py
@@ -1,0 +1,84 @@
+"""Enhanced Gradio UI with voice input and quick question tiles."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import gradio as gr
+
+from .llm_client import answer_question
+from .retrieval import BM25Index, md_to_pages
+from . import whisper_local
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+FREQ_PATH = Path(__file__).resolve().parent.parent / "frequent_questions.json"
+
+
+def _load_index() -> BM25Index:
+    """Build BM25 index from Markdown files in :data:`DATA_DIR`."""
+    pages: list[str] = []
+    for md_path in DATA_DIR.glob("*.md"):
+        pages.extend(md_to_pages(md_path.read_text(encoding="utf-8")))
+    return BM25Index(pages)
+
+
+INDEX = _load_index()
+
+
+def handle_question(question: str) -> tuple[str, str, str]:
+    """Retrieve answer, debug info and context for ``question``."""
+    return answer_question(INDEX, question)
+
+
+def load_frequent_questions() -> Iterable[str]:
+    """Load predefined frequent questions from :data:`FREQ_PATH`."""
+    if FREQ_PATH.exists():
+        return json.loads(FREQ_PATH.read_text(encoding="utf-8"))
+    return []
+
+
+def transcribe_audio(audio_path: str) -> str:
+    """Transcribe audio input into text using Whisper."""
+    return whisper_local.transcribe(audio_path)
+
+
+def fill_question(text: str) -> str:
+    """Utility callback that simply returns provided text."""
+    return text
+
+
+def build_app() -> gr.Blocks:
+    """Create Gradio Blocks application with voice and FAQ tiles."""
+    with gr.Blocks(css=".gr-textbox textarea {font-size: 14px}") as demo:
+        gr.Markdown(
+            """
+        # 📜 Gothic LARP – Podręcznik Q&A (RAG)
+        Wpisz lub nagraj pytanie dotyczące zasad. Aplikacja automatycznie wczytuje pliki Markdown z katalogu `data`.
+        """
+        )
+
+        q = gr.Textbox(label="Twoje pytanie", placeholder="Np. Jak się walczy?", lines=2)
+
+        with gr.Row():
+            audio = gr.Audio(sources=["microphone"], type="filepath", label="🎤")
+            transcribe_btn = gr.Button("Transkrybuj")
+
+        with gr.Row():
+            for question in load_frequent_questions():
+                gr.Button(question).click(fn=lambda x=question: x, inputs=None, outputs=q)
+
+        ask = gr.Button("Zapytaj", variant="primary")
+        answer = gr.Markdown(label="Odpowiedź")
+        debug_bar = gr.Markdown(label="Debug")
+        context = gr.Markdown(label="Źródła i kontekst")
+
+        transcribe_btn.click(transcribe_audio, inputs=audio, outputs=q)
+        ask.click(fn=handle_question, inputs=q, outputs=[answer, debug_bar, context])
+
+    return demo
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    app = build_app()
+    app.launch(server_name="0.0.0.0", server_port=7860, inbrowser=False)

--- a/src/whisper_local.py
+++ b/src/whisper_local.py
@@ -1,0 +1,57 @@
+"""Utilities for local speech-to-text transcription using Whisper."""
+from __future__ import annotations
+
+from typing import Any, Optional
+import importlib
+
+_MODEL: Optional[Any] = None
+
+
+def _get_model(model_name: str) -> Any:
+    """Load and cache a Whisper model.
+
+    Parameters
+    ----------
+    model_name:
+        Name of the Whisper model to load.
+
+    Returns
+    -------
+    Any
+        Loaded Whisper model instance.
+
+    Raises
+    ------
+    RuntimeError
+        If the `whisper` package is not installed.
+    """
+    global _MODEL
+    if _MODEL is None:
+        try:
+            whisper = importlib.import_module("whisper")
+        except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+            raise RuntimeError("whisper package is required for transcription") from exc
+        _MODEL = whisper.load_model(model_name)
+    return _MODEL
+
+
+def transcribe(audio_path: str, model_name: str = "base") -> str:
+    """Transcribe speech from an audio file path.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to an audio file supported by Whisper.
+    model_name:
+        Name of the Whisper model to use. Defaults to ``"base"``.
+
+    Returns
+    -------
+    str
+        Transcribed text or empty string if transcription fails.
+    """
+    if not audio_path:
+        return ""
+    model = _get_model(model_name)
+    result = model.transcribe(audio_path)
+    return result.get("text", "").strip()

--- a/tests/test_gradio_ui.py
+++ b/tests/test_gradio_ui.py
@@ -1,0 +1,12 @@
+"""Smoke tests for Gradio UI helpers."""
+from __future__ import annotations
+
+import gradio as gr
+
+from src import gradio_ui
+
+
+def test_build_app_returns_blocks() -> None:
+    """UI builder should return a :class:`gradio.Blocks` instance."""
+    app = gradio_ui.build_app()
+    assert isinstance(app, gr.Blocks)

--- a/tests/test_whisper_local.py
+++ b/tests/test_whisper_local.py
@@ -1,0 +1,24 @@
+"""Tests for the ``whisper_local`` transcription helper."""
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock
+
+from src import whisper_local
+
+
+def test_transcribe_uses_whisper(monkeypatch, tmp_path):
+    """``transcribe`` delegates to the underlying Whisper model."""
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = {"text": "hello"}
+    fake_whisper = types.SimpleNamespace(load_model=MagicMock(return_value=fake_model))
+    monkeypatch.setattr(whisper_local.importlib, "import_module", lambda _: fake_whisper)
+
+    audio = tmp_path / "sample.wav"
+    audio.write_bytes(b"data")
+
+    text = whisper_local.transcribe(str(audio))
+
+    assert text == "hello"
+    fake_whisper.load_model.assert_called_once_with("base")
+    fake_model.transcribe.assert_called_once_with(str(audio))


### PR DESCRIPTION
## Summary
- add local Whisper transcription helper and tests
- add microphone input with transcription and FAQ tiles in Gradio UI

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b456479fc4832198df29bdb14be1a9