### PR TITLE
Clamp FAISS search k to index size

### DIFF
--- a/src/retriever_vector.py
+++ b/src/retriever_vector.py
@@ -49,6 +49,9 @@ class VectorIndex:
         """Return top-k pages most similar to query."""
         q_emb = self.model.encode([query], convert_to_numpy=True, show_progress_bar=False)
         faiss.normalize_L2(q_emb)
+        k = min(k, len(self.pages))
+        if k == 0:
+            return []
         scores, idx = self.index.search(q_emb, k)
         results: List[Dict] = []
         for rank, i in enumerate(idx[0]):


### PR DESCRIPTION
## Summary
- prevent `VectorIndex.search` from requesting more results than are indexed
- return empty result set when index is empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45e7365788321b678e352dffd6153