### PR TITLE
feat: add frequent question tiles

### DIFF
--- a/frequent_questions.json
+++ b/frequent_questions.json
@@ -1,0 +1,7 @@
+{
+  "questions": [
+    "Jak się walczy?",
+    "Jak działają zaklęcia?",
+    "Jak zdobyć punkty doświadczenia?"
+  ]
+}

--- a/tests/test_frequent_questions.py
+++ b/tests/test_frequent_questions.py
@@ -1,0 +1,8 @@
+from src.gradio_ui import load_frequent_questions
+
+
+def test_load_frequent_questions():
+    questions = load_frequent_questions()
+    assert isinstance(questions, list)
+    assert questions[0] == "Jak się walczy?"
+    assert all(isinstance(q, str) for q in questions)


### PR DESCRIPTION
## Summary
- add preset frequent question tiles to start page
- load questions from new JSON file and handle clicks
- cover loader with basic test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4634ef5bc832198979782fff04e9e