### PR TITLE
feat(rag): hybrid default + rerank + top2 context

### DIFF
--- a/modules/logic/llm_client.py
+++ b/modules/logic/llm_client.py
@@ -6,7 +6,7 @@ import requests
 from .config import LLAMA_BASE_URL, LLAMA_MODEL, MAX_TOKENS, STOP, TEMPERATURE
 from .intent_embedder import parse_intent
 from modules.prompting.prompt_enhancer import enhance_prompt
-from modules.retrieval.retrieval import BM25Index
+from modules.retrieval.retriever_interface import RetrieverInterface
 from .metrics_logger import MetricsLogger
 from .query_monitor import log_query
 from .logger_async import async_logger
@@ -53,7 +53,7 @@ def _log(prompt: str, answer: str) -> None:
     async_logger.log(prompt, answer)
 
 
-def answer_question(idx: BM25Index, question: str, top_k: int = 3, seed: int = 42) -> Tuple[str, str, str]:
+def answer_question(idx: RetrieverInterface, question: str, top_k: int = 3, seed: int = 42) -> Tuple[str, str, str]:
     """Handle question answering using retrieval and LLM."""
     logger = MetricsLogger()
     logger.start()

--- a/modules/retrieval/retriever_hybrid.py
+++ b/modules/retrieval/retriever_hybrid.py
@@ -1,35 +1,116 @@
-"""Hybrid retriever combining BM25 and vector similarity via reciprocal rank fusion."""
+"""Hybrid retriever combining BM25 and vector similarity with reranking."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, List
-from .retriever_interface import RetrieverInterface
+import hashlib
+import logging
 
+import faiss
+import numpy as np
+import yaml
+
+from .retriever_interface import RetrieverInterface
 from .retrieval import BM25Index
 from .retriever_vector import VectorIndex
 
 
-class HybridRetriever(RetrieverInterface):
-    """Combine BM25 and vector search using Reciprocal Rank Fusion."""
+log = logging.getLogger(__name__)
 
-    def __init__(self, bm25: BM25Index, vector: VectorIndex):
+
+def _load_cfg() -> Dict:
+    """Load retrieval configuration from ``settings.yaml`` if present."""
+    cfg_path = Path(__file__).resolve().parents[2] / "settings.yaml"
+    try:
+        with cfg_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("retrieval", {})
+    except Exception:  # pragma: no cover - missing config
+        return {}
+
+
+CFG = _load_cfg()
+
+
+class HybridRetriever(RetrieverInterface):
+    """Combine BM25 and vector search using Reciprocal Rank Fusion + rerank."""
+
+    def __init__(
+        self,
+        bm25: BM25Index,
+        vector: VectorIndex,
+        *,
+        top_k_bm25: int | None = None,
+        top_k_vec: int | None = None,
+        k_final: int | None = None,
+        max_chunks: int | None = None,
+        min_similarity: float | None = None,
+    ) -> None:
         self.bm25 = bm25
         self.vector = vector
+        self.top_k_bm25 = top_k_bm25 or int(CFG.get("top_k_bm25", 8))
+        self.top_k_vec = top_k_vec or int(CFG.get("top_k_vec", 8))
+        self.k_final = k_final or int(CFG.get("k_final", 5))
+        self.max_chunks = max_chunks or int(CFG.get("max_chunks", 2))
+        self.min_similarity = min_similarity if min_similarity is not None else float(
+            CFG.get("min_similarity", 0.2)
+        )
 
-    def search(self, query: str, k: int = 4) -> List[Dict]:
-        """Return fused results from BM25 and vector search."""
-        b_res = self.bm25.search(query, k)
-        v_res = self.vector.search(query, k)
+    def _vector_search(self, q_emb: np.ndarray) -> List[Dict]:
+        """Search FAISS index with precomputed query embedding."""
+        k = min(self.top_k_vec, len(self.vector.pages))
+        if k == 0:
+            return []
+        scores, idx = self.vector.index.search(q_emb, k)
+        results: List[Dict] = []
+        for rank, i in enumerate(idx[0]):
+            p = dict(self.vector.pages[i])
+            p["score"] = float(scores[0][rank])
+            results.append(p)
+        return results
+
+    def search(self, query: str, k: int | None = None) -> List[Dict]:
+        """Return up to ``max_chunks`` reranked results for ``query``."""
+        q_emb = self.vector.model.encode([query], convert_to_numpy=True, show_progress_bar=False)
+        faiss.normalize_L2(q_emb)
+
+        b_res = self.bm25.search(query, self.top_k_bm25)
+        v_res = self._vector_search(q_emb)
+
         rrf_scores: Dict[int, float] = {}
         for rank, res in enumerate(b_res):
             rrf_scores[res["page"]] = rrf_scores.get(res["page"], 0.0) + 1.0 / (60 + rank + 1)
         for rank, res in enumerate(v_res):
             rrf_scores[res["page"]] = rrf_scores.get(res["page"], 0.0) + 1.0 / (60 + rank + 1)
+
         page_map = {p["page"]: p for p in self.bm25.pages}
-        ranked = sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True)[:k]
-        results: List[Dict] = []
-        for page, score in ranked:
+        k_final = k or self.k_final
+        ranked = sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True)[:k_final]
+
+        # Rerank by cosine similarity and remove duplicates/low scores
+        scored: List[tuple[float, Dict]] = []
+        for page, _ in ranked:
             p = dict(page_map[page])
-            p["score"] = float(score)
+            emb = self.vector.model.encode([p["text"]], convert_to_numpy=True, show_progress_bar=False)
+            faiss.normalize_L2(emb)
+            sim = float(np.dot(q_emb[0], emb[0]))
+            if sim < self.min_similarity:
+                continue
+            p["score"] = sim
             p["preview"] = (p["text"][:600] + ("…" if len(p["text"]) > 600 else "")).replace("\n", " ")
+            scored.append((sim, p))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        seen: set[str] = set()
+        results: List[Dict] = []
+        for sim, p in scored:
+            h = hashlib.sha1(p["text"].strip().lower().encode("utf-8")).hexdigest()
+            if h in seen:
+                continue
+            seen.add(h)
             results.append(p)
+            if len(results) >= self.max_chunks:
+                break
+
+        log.info("chunks_selected=%d", len(results))
         return results

--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -4,22 +4,23 @@ from pathlib import Path
 import gradio as gr
 
 from modules.logic.llm_client import answer_question
-from modules.retrieval.retrieval import BM25Index, md_to_pages
+from modules.retrieval import create_retriever, md_to_pages
+from modules.retrieval.retriever_interface import RetrieverInterface
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 
 
-_INDEX: BM25Index | None = None
+_INDEX: RetrieverInterface | None = None
 
 
-def _load_index() -> BM25Index:
+def _load_index() -> RetrieverInterface:
     pages = []
     for md_path in DATA_DIR.glob("*.md"):
         pages.extend(md_to_pages(md_path.read_text(encoding="utf-8")))
-    return BM25Index(pages)
+    return create_retriever("hybrid", pages)
 
 
-def _get_index() -> BM25Index:
+def _get_index() -> RetrieverInterface:
     global _INDEX
     if _INDEX is None:
         _INDEX = _load_index()

--- a/modules/ui/gradio_ui.py
+++ b/modules/ui/gradio_ui.py
@@ -9,22 +9,23 @@ import gradio as gr
 
 from modules.logic import debug_mode
 from modules.logic.llm_client import answer_question
-from modules.retrieval.retrieval import BM25Index, md_to_pages
+from modules.retrieval import create_retriever, md_to_pages
+from modules.retrieval.retriever_interface import RetrieverInterface
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 
 
-_INDEX: BM25Index | None = None
+_INDEX: RetrieverInterface | None = None
 
 
-def _load_index() -> BM25Index:
+def _load_index() -> RetrieverInterface:
     pages = []
     for md_path in DATA_DIR.glob("*.md"):
         pages.extend(md_to_pages(md_path.read_text(encoding="utf-8")))
-    return BM25Index(pages)
+    return create_retriever("hybrid", pages)
 
 
-def _get_index() -> BM25Index:
+def _get_index() -> RetrieverInterface:
     global _INDEX
     if _INDEX is None:
         _INDEX = _load_index()

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,1 +1,7 @@
 confidence_threshold: 0.3
+retrieval:
+  top_k_bm25: 8
+  top_k_vec: 8
+  k_final: 5
+  max_chunks: 2
+  min_similarity: 0.2

--- a/tests/test_retriever_hybrid.py
+++ b/tests/test_retriever_hybrid.py
@@ -33,7 +33,9 @@ def test_vector_search(vector_index):
     assert len(res) > 0
 
 
-def test_hybrid_search(bm25_index, vector_index):
+def test_hybrid_search_top2_and_logs(bm25_index, vector_index, caplog):
     hybrid = HybridRetriever(bm25_index, vector_index)
-    res = hybrid.search("Jak się walczy?")
-    assert len(res) > 0
+    with caplog.at_level("INFO"):
+        res = hybrid.search("Jak się walczy?")
+    assert 1 <= len(res) <= 2
+    assert any("chunks_selected=" in m for m in caplog.text.splitlines())


### PR DESCRIPTION
## Summary
- add hybrid retrieval pipeline combining BM25 and FAISS with RRF, cosine rerank, deduplication, and top-2 context limit
- configure retrieval defaults via settings.yaml and switch UI to hybrid retriever
- log selected chunk count and ensure tests cover top2 and logging behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b479eb7dd083219e50fb998a5c5356