### PR TITLE
feat(prompt): human tutor style + inline citations + no-echo filter

### DIFF
--- a/modules/prompting/meta_response.py
+++ b/modules/prompting/meta_response.py
@@ -1,8 +1,8 @@
 """Helpers for meta-level responses such as self-introduction."""
 
-# H1.4: self-introduction as Pomocnik Gothic LARP
+# H1.4: self-introduction in tutor style
 
 def with_introduction(message: str) -> str:
-    """Prefix message with a friendly self-introduction."""
-    intro = "Cześć! Jestem Pomocnik Gothic LARP."
+    """Prefix message with a friendly tutor-style introduction."""
+    intro = "Cześć! Jestem twój przyjazny tutor Gothic LARP."
     return f"{intro} {message}"

--- a/modules/prompting/prompt_enhancer.py
+++ b/modules/prompting/prompt_enhancer.py
@@ -6,16 +6,14 @@ def enhance_prompt(question: str, intent: Dict, context: str) -> str:
     """Return prompt with intent metadata and context."""
     intent_line = f"Dopasowane pytanie: {intent.get('match', '')} (pewność {intent.get('confidence', 0):.2f})"
     answer_format = (
-        "FORMAT ODPOWIEDZI (stosuj dokładnie):\n"
-        "Odpowiedź: <2–4 krótkie zdania, tylko fakty z najtrafniejszych fragmentów powiązanych z tematem pytania (np. 'walka', 'magia'). Jeśli brak – napisz: 'Nie ma tego w podręczniku.'>\n"
-        "Nie cytuj fragmentów niepowiązanych tematycznie (np. alchemii dla pytania o walkę).\n"
-        "Cytaty: \"<cytat1>\" ; \"<cytat2>\" (każdy ≤ 20 słów, dosłownie z kontekstu; jeśli masz tylko jeden – podaj jeden)\n"
-        "Źródła: [Strona X — Sekcja: Y]; [Strona …]"
+        "Udziel odpowiedzi w 2–4 krótkich zdaniach, tylko na podstawie powyższych fragmentów. "
+        "Wpleć 1–2 cytaty (≤ 20 słów) z najtrafniejszych części. "
+        "Na końcu dodaj: Źródło: Strona X – Sekcja Y."
     )
     return (
         f"Pytanie użytkownika: {question}\n"
         f"{intent_line}\n\n"
         f"Najtrafniejsze fragmenty podręcznika (numerowane):\n{context}\n\n"
         f"{answer_format}\n\n"
-        "Instrukcje: Odpowiadaj tylko na podstawie powyższych fragmentów. Nie wymyślaj, nie dodawaj nic poza formatem."
+        "Instrukcje: Odpowiadaj tylko na podstawie powyższych fragmentów. Jeśli brak odpowiedzi – napisz: 'Nie ma tego w podręczniku.'"
     )

--- a/modules/prompting/prompt_templates.py
+++ b/modules/prompting/prompt_templates.py
@@ -3,23 +3,18 @@ from typing import List, Tuple
 
 # H1.1: system prompt in a more natural human tone
 SYSTEM_PROMPT = (
-    "Cześć! Jestem Pomocnik Gothic LARP — twój serdeczny przewodnik po zasadach "
-    "i świecie gry. Mówię prostym językiem, korzystam tylko z przekazanego "
-    "kontekstu i staram się być pomocny jak towarzysz przy ognisku."
+    "Jestem przyjaznym tutorem Gothic LARP dla nowego gracza. "
+    "Tłumaczę krok po kroku i korzystam wyłącznie z dostarczonego kontekstu."
 )
 
 # H1.2: few-shot Q&A examples for context prompting
 FEWSHOT_QA: List[Tuple[str, str]] = [
     (
-        "Jak wygląda walka w nocy?",
-        "W nocy walka staje się trudniejsza, bo słabsza widoczność wpływa na pewność ciosów.",
+        "Jak działa magia ognia?",
+        "Na początek, \"ognia chwała\" budzi płomień w dłoni. Źródło: Strona 12 – Sekcja Magia ognia.",
     ),
     (
-        "Czy mogę stworzyć własną runę?",
-        "Tworzenie nowych run to rzadkość, ale doświadczeni magowie mogą się tego podjąć.",
-    ),
-    (
-        "Ile trwa nauka dwuręcznego miecza?",
-        "Opanowanie walki dwuręcznym mieczem wymaga wielu miesięcy treningu i dobrej kondycji.",
+        "Co robi nowicjusz na początku?",
+        "Nowy gracz najpierw \"uczy się podstaw przy ognisku\". Źródło: Strona 3 – Sekcja Wprowadzenie.",
     ),
 ]

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -38,6 +38,7 @@ def test_answer_question_preserves_order_on_low_conf(monkeypatch):
     monkeypatch.setattr(llm_client, "call_llama", lambda messages, seed: "odp")
 
     ans, debug, ctx = llm_client.answer_question(DummyIndex(), "Jak się walczy?")
-    assert ans == "odp"
+    assert ans.startswith("odp")
+    assert ans.endswith("Sekcja Alchemia.")
     assert "Sekcje: 1:Alchemia, 2:Walka, 3:Smierc" in debug
     assert ctx.splitlines()[0].startswith("[1] Strona 1")

--- a/tests/test_meta_response.py
+++ b/tests/test_meta_response.py
@@ -9,5 +9,5 @@ from src import meta_response
 def test_with_introduction_adds_prefix():
     message = "Odpowiedź"
     out = meta_response.with_introduction(message)
-    assert out.startswith("Cześć! Jestem Pomocnik Gothic LARP.")
+    assert out.startswith("Cześć! Jestem twój przyjazny tutor Gothic LARP.")
     assert message in out

--- a/tests/test_prompt_enhancer.py
+++ b/tests/test_prompt_enhancer.py
@@ -12,5 +12,5 @@ def test_enhance_prompt_mentions_topic_relevance():
         {"match": "walka", "confidence": 0.7},
         "[1] Strona 1 — Sekcja: Walka\nPrzykładowy tekst"
     )
-    assert "najtrafniejszych fragmentów powiązanych z tematem pytania" in prompt
-    assert "Nie cytuj fragmentów niepowiązanych tematycznie" in prompt
+    assert "Wpleć 1–2 cytaty" in prompt
+    assert "Źródło: Strona X – Sekcja Y" in prompt

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -7,7 +7,7 @@ from src import prompt_templates
 
 
 def test_system_prompt_mentions_helper():
-    assert "Pomocnik Gothic LARP" in prompt_templates.SYSTEM_PROMPT
+    assert "przyjaznym tutorem" in prompt_templates.SYSTEM_PROMPT
 
 
 def test_fewshot_nonempty():


### PR DESCRIPTION
## Summary
- adopt friendly tutor system prompt with few-shot examples
- embed inline quotes and final source; paraphrase if answer echoes question
- update tests for new prompt format and response style

## Testing
- `pytest`
- manual: 5 sample questions through llm_client.answer_question

------
https://chatgpt.com/codex/tasks/task_e_68b47b285b5483219fce34f6199468ad