### PR TITLE
feat(core): persisted indexes by default + rotating logs + richer metrics

### DIFF
--- a/modules/logic/__init__.py
+++ b/modules/logic/__init__.py
@@ -1,7 +1,7 @@
 from .config import LLAMA_BASE_URL, LLAMA_MODEL, MAX_TOKENS, STOP, TEMPERATURE
 from .intent_embedder import parse_intent
 from .metrics_logger import MetricsLogger
-from .query_monitor import log_query
+from .query_monitor import log_metrics, log_query
 from .utils import tokenize_for_bm25
 from .debug_mode import is_debug, set_debug
 __all__ = [
@@ -13,6 +13,7 @@ __all__ = [
     "parse_intent",
     "MetricsLogger",
     "log_query",
+    "log_metrics",
     "tokenize_for_bm25",
     "is_debug",
     "set_debug",

--- a/modules/logic/index_loader.py
+++ b/modules/logic/index_loader.py
@@ -1,8 +1,12 @@
-"""Utilities for serializing and loading BM25 and FAISS indexes."""
+"""Utilities for serializing, loading and caching BM25 and FAISS indexes."""
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 import pickle
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable, Tuple
 
 import faiss
 
@@ -27,3 +31,70 @@ def save_faiss(index: faiss.Index, path: str) -> None:
 def load_faiss(path: str) -> faiss.Index:
     """Load FAISS index from ``path``."""
     return faiss.read_index(path)
+
+
+# ---------------------------------------------------------------------------
+
+def _file_meta(path: str) -> dict:
+    """Return sha256 hash and mtime for ``path``."""
+    stat = os.stat(path)
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return {"hash": h.hexdigest(), "mtime": stat.st_mtime}
+
+
+def load_or_build(
+    data_path: str,
+    builder: Callable[[], Tuple[Any, faiss.Index]],
+    *,
+    cache_dir: str = "serialized_index",
+    bm25_name: str = "bm25.pkl",
+    faiss_name: str = "faiss.bin",
+    meta_name: str = "meta.json",
+) -> Tuple[Any, faiss.Index]:
+    """Load indexes from disk if metadata matches ``data_path`` or rebuild.
+
+    Parameters
+    ----------
+    data_path:
+        Source file used to build indexes.
+    builder:
+        Callable returning ``(bm25_index, faiss_index)`` when rebuild is needed.
+    cache_dir:
+        Directory where serialized indexes and metadata live.
+    """
+
+    cdir = Path(cache_dir)
+    bm25_path = cdir / bm25_name
+    faiss_path = cdir / faiss_name
+    meta_path = cdir / meta_name
+
+    if bm25_path.exists() and faiss_path.exists() and meta_path.exists():
+        try:
+            with meta_path.open("r", encoding="utf-8") as f:
+                meta = json.load(f)
+            current = _file_meta(data_path)
+            if meta == current:
+                return load_bm25(str(bm25_path)), load_faiss(str(faiss_path))
+        except Exception:  # pragma: no cover - corrupted cache
+            pass
+
+    cdir.mkdir(parents=True, exist_ok=True)
+    bm25, vec = builder()
+    save_bm25(bm25, str(bm25_path))
+    save_faiss(vec, str(faiss_path))
+    meta = _file_meta(data_path)
+    with meta_path.open("w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    return bm25, vec
+
+
+__all__ = [
+    "save_bm25",
+    "load_bm25",
+    "save_faiss",
+    "load_faiss",
+    "load_or_build",
+]

--- a/modules/logic/logger_async.py
+++ b/modules/logic/logger_async.py
@@ -1,39 +1,50 @@
-"""Asynchronous prompt/answer logging using a background thread."""
+"""Asynchronous logger with rotating file handler and request correlation."""
 from __future__ import annotations
 
 import atexit
-import queue
-import threading
+import logging
+from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
 from pathlib import Path
+from queue import Queue
 
 
 class AsyncLogger:
-    """Logger writing entries to disk without blocking the main thread."""
+    """Queue-based logger writing to rotating files."""
 
-    def __init__(self, path: str = "user_logs/async_log.txt"):
+    def __init__(
+        self,
+        path: str = "user_logs/async_log.txt",
+        *,
+        max_bytes: int = 5 * 1024 * 1024,
+        backup_count: int = 10,
+    ) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.queue: "queue.Queue[str | None]" = queue.Queue()
-        self.thread = threading.Thread(target=self._worker, daemon=True)
-        self.thread.start()
+
+        self.queue: Queue = Queue()
+        handler = RotatingFileHandler(
+            self.path,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
+        fmt = logging.Formatter("%(asctime)s [%(request_id)s] %(message)s")
+        handler.setFormatter(fmt)
+
+        self.logger = logging.getLogger("async_logger")
+        self.logger.setLevel(logging.INFO)
+        self.logger.addHandler(QueueHandler(self.queue))
+
+        self.listener = QueueListener(self.queue, handler)
+        self.listener.start()
         atexit.register(self.close)
 
-    def _worker(self) -> None:
-        with self.path.open("a", encoding="utf-8") as f:
-            while True:
-                msg = self.queue.get()
-                if msg is None:
-                    break
-                f.write(msg)
-                f.flush()
-
-    def log(self, prompt: str, answer: str) -> None:
-        entry = f"PROMPT:\n{prompt}\n\nANSWER:\n{answer}\n" + "-" * 40 + "\n"
-        self.queue.put(entry)
+    def log(self, prompt: str, answer: str, request_id: str) -> None:
+        entry = f"PROMPT:\n{prompt}\n\nANSWER:\n{answer}\n" + "-" * 40
+        self.logger.info(entry, extra={"request_id": request_id})
 
     def close(self) -> None:
-        self.queue.put(None)
-        self.thread.join(timeout=1)
+        self.listener.stop()
 
 
 async_logger = AsyncLogger()

--- a/modules/logic/query_monitor.py
+++ b/modules/logic/query_monitor.py
@@ -1,6 +1,5 @@
+"""Anonymised logging of user queries with basic performance metrics."""
 from __future__ import annotations
-
-"""Anonymised logging of user queries."""
 
 import json
 import os
@@ -12,21 +11,39 @@ DEFAULT_LOG_DIR = Path.home() / ".llm_lg_ui" / "user_logs"
 LOG_DIR = Path(os.getenv("LLM_LG_UI_LOG_DIR", DEFAULT_LOG_DIR))
 
 
-def log_query(query: str) -> Path:
+def log_query(query: str) -> str:
     """Persist query with random UUID and timestamp.
 
-    Parameters
-    ----------
-    query: str
-        Raw user question to store.
+    Returns generated ``request_id`` for correlation.
     """
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    request_id = str(uuid.uuid4())
     entry = {
-        "uuid": str(uuid.uuid4()),
+        "uuid": request_id,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "query": query,
     }
-    path = LOG_DIR / f"{entry['uuid']}.json"
+    path = LOG_DIR / f"{request_id}.json"
     with path.open("w", encoding="utf-8") as f:
         json.dump(entry, f, ensure_ascii=False)
-    return path
+    return request_id
+
+
+def log_metrics(request_id: str, *, chunks_selected: int, citations_used: int) -> None:
+    """Append latency and retrieval metrics for ``request_id`` entry."""
+    path = LOG_DIR / f"{request_id}.json"
+    if not path.exists():  # pragma: no cover - missing entry
+        return
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    start = datetime.fromisoformat(data["timestamp"])
+    latency = int((datetime.now(timezone.utc) - start).total_seconds() * 1000)
+    data.update(
+        {
+            "latency_ms": latency,
+            "chunks_selected": chunks_selected,
+            "citations_used": citations_used,
+        }
+    )
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False)

--- a/tests/test_index_loader.py
+++ b/tests/test_index_loader.py
@@ -5,7 +5,7 @@ import faiss
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from src.index_loader import load_bm25, load_faiss, save_bm25, save_faiss
+from src.index_loader import load_bm25, load_faiss, save_bm25, save_faiss, load_or_build
 from src.retrieval import BM25Index, md_to_pages
 from src.retriever_vector import VectorIndex
 
@@ -30,3 +30,23 @@ def test_index_serialization(tmp_path):
     faiss.normalize_L2(q)
     scores, idxs = vec_loaded.search(q, 1)
     assert idxs.shape[1] == 1
+
+
+
+def test_load_or_build(tmp_path):
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    rules_path = os.path.join(base_dir, "data", "rules.md")
+    calls = {"n": 0}
+    def builder():
+        calls["n"] += 1
+        with open(rules_path, "r", encoding="utf-8") as f:
+            pages = md_to_pages(f.read())
+        bm25 = BM25Index(pages)
+        vector = VectorIndex(pages)
+        return bm25, vector.index
+    bm25_idx, faiss_idx = load_or_build(rules_path, builder, cache_dir=str(tmp_path))
+    assert calls["n"] == 1
+    bm25_idx2, faiss_idx2 = load_or_build(rules_path, builder, cache_dir=str(tmp_path))
+    assert calls["n"] == 1
+    assert bm25_idx2.search("Jak się walczy?")
+    assert faiss_idx2.ntotal > 0

--- a/tests/test_query_monitor.py
+++ b/tests/test_query_monitor.py
@@ -1,0 +1,18 @@
+import json
+from importlib import reload
+
+import modules.logic.query_monitor as qm
+
+
+def test_query_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_LG_UI_LOG_DIR", str(tmp_path))
+    reload(qm)
+    req_id = qm.log_query("co to jest?")
+    qm.log_metrics(req_id, chunks_selected=3, citations_used=50)
+    path = tmp_path / f"{req_id}.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["query"] == "co to jest?"
+    assert data["chunks_selected"] == 3
+    assert data["citations_used"] == 50
+    assert "latency_ms" in data


### PR DESCRIPTION
## Summary
- load BM25/FAISS indexes from disk when source unchanged
- rotate async logs with request correlation id
- collect latency and citation metrics per query

## Testing
- `pytest tests/test_index_loader.py tests/test_query_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_68b47d35e2208321a271286ea93bb0e8